### PR TITLE
注释修改以及_epoll_thread_attr 移动到cpp文件中

### DIFF
--- a/src/brpc/event_dispatcher.h
+++ b/src/brpc/event_dispatcher.h
@@ -94,9 +94,6 @@ private:
     // The attribute of bthreads calling user callbacks.
     bthread_attr_t _consumer_thread_attr;
 
-    // The attribute of bthread epoll_wait.
-    bthread_attr_t _epoll_thread_attr;
-
     // Pipe fds to wakeup EventDispatcher from `epoll_wait' in order to quit
     int _wakeup_fds[2];
 };

--- a/src/brpc/event_dispatcher_epoll.cpp
+++ b/src/brpc/event_dispatcher_epoll.cpp
@@ -68,7 +68,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
         return -1;
     }
 
-    // Set _consumer_thread_attr before creating epoll/kqueue thread to make sure
+    // Set _consumer_thread_attr before creating epoll thread to make sure
     // everyting seems sane to the thread.
     _consumer_thread_attr = (consumer_thread_attr  ?
                              *consumer_thread_attr : BTHREAD_ATTR_NORMAL);
@@ -85,7 +85,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
     int rc = bthread_start_background(
         &_tid, &_epoll_thread_attr, RunThis, this);
     if (rc) {
-        LOG(FATAL) << "Fail to create epoll/kqueue thread: " << berror(rc);
+        LOG(FATAL) << "Fail to create epoll thread: " << berror(rc);
         return -1;
     }
     return 0;

--- a/src/brpc/event_dispatcher_epoll.cpp
+++ b/src/brpc/event_dispatcher_epoll.cpp
@@ -75,7 +75,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
 
     //_consumer_thread_attr is used in StartInputEvent(), assign flag NEVER_QUIT to it will cause new bthread
     // that created by epoll_wait() never to quit.
-    _epoll_thread_attr = _consumer_thread_attr | BTHREAD_NEVER_QUIT;
+    bthread_attr_t epoll_thread_attr = _consumer_thread_attr | BTHREAD_NEVER_QUIT;
 
     // Polling thread uses the same attr for consumer threads (NORMAL right
     // now). Previously, we used small stack (32KB) which may be overflowed
@@ -83,7 +83,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
     // is also a potential issue for consumer threads, using the same attr
     // should be a reasonable solution.
     int rc = bthread_start_background(
-        &_tid, &_epoll_thread_attr, RunThis, this);
+        &_tid, &epoll_thread_attr, RunThis, this);
     if (rc) {
         LOG(FATAL) << "Fail to create epoll thread: " << berror(rc);
         return -1;

--- a/src/brpc/event_dispatcher_kqueue.cpp
+++ b/src/brpc/event_dispatcher_kqueue.cpp
@@ -74,8 +74,8 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
                              *consumer_thread_attr : BTHREAD_ATTR_NORMAL);
 
     //_consumer_thread_attr is used in StartInputEvent(), assign flag NEVER_QUIT to it will cause new bthread
-    // that created by epoll_wait() never to quit.
-    _epoll_thread_attr = _consumer_thread_attr | BTHREAD_NEVER_QUIT;
+    // that created by kevent() never to quit.
+    bthread_attr_t kqueue_thread_attr = _consumer_thread_attr | BTHREAD_NEVER_QUIT;
 
     // Polling thread uses the same attr for consumer threads (NORMAL right
     // now). Previously, we used small stack (32KB) which may be overflowed
@@ -83,7 +83,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
     // is also a potential issue for consumer threads, using the same attr
     // should be a reasonable solution.
     int rc = bthread_start_background(
-        &_tid, &_epoll_thread_attr, RunThis, this);
+        &_tid, &kqueue_thread_attr, RunThis, this);
     if (rc) {
         LOG(FATAL) << "Fail to create kqueue thread: " << berror(rc);
         return -1;
@@ -169,9 +169,9 @@ int EventDispatcher::RemoveConsumer(int fd) {
     // Removing the consumer from dispatcher before closing the fd because
     // if process was forked and the fd is not marked as close-on-exec,
     // closing does not set reference count of the fd to 0, thus does not
-    // remove the fd from epoll. More badly, the fd will not be removable
-    // from epoll again! If the fd was level-triggered and there's data left,
-    // epoll_wait will keep returning events of the fd continuously, making
+    // remove the fd from kqueue More badly, the fd will not be removable
+    // from kqueue again! If the fd was level-triggered and there's data left,
+    // kevent will keep returning events of the fd continuously, making
     // program abnormal.
     struct kevent evt;
     EV_SET(&evt, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);

--- a/src/brpc/event_dispatcher_kqueue.cpp
+++ b/src/brpc/event_dispatcher_kqueue.cpp
@@ -68,7 +68,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
         return -1;
     }
 
-    // Set _consumer_thread_attr before creating epoll/kqueue thread to make sure
+    // Set _consumer_thread_attr before creating kqueue thread to make sure
     // everyting seems sane to the thread.
     _consumer_thread_attr = (consumer_thread_attr  ?
                              *consumer_thread_attr : BTHREAD_ATTR_NORMAL);
@@ -85,7 +85,7 @@ int EventDispatcher::Start(const bthread_attr_t* consumer_thread_attr) {
     int rc = bthread_start_background(
         &_tid, &_epoll_thread_attr, RunThis, this);
     if (rc) {
-        LOG(FATAL) << "Fail to create epoll/kqueue thread: " << berror(rc);
+        LOG(FATAL) << "Fail to create kqueue thread: " << berror(rc);
         return -1;
     }
     return 0;


### PR DESCRIPTION
_epoll_thread_attr 移动到cpp文件中。不在头文件中声明。避免命名歧义
其他注释修改